### PR TITLE
Add MCP registry validation label for Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,6 +46,7 @@ jobs:
             org.opencontainers.image.description=Model Context Protocol server for ZenML
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=MIT
+            io.modelcontextprotocol.server.name=io.github.zenml-io/mcp-zenml
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -42,6 +42,7 @@ jobs:
             org.opencontainers.image.description=Model Context Protocol server for ZenML
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=MIT
+            io.modelcontextprotocol.server.name=io.github.zenml-io/mcp-zenml
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY --chown=appuser:appuser server/zenml_server.py /app/server/zenml_server.py
 LABEL org.opencontainers.image.title="ZenML MCP Server" \
       org.opencontainers.image.description="Model Context Protocol server for ZenML" \
       org.opencontainers.image.source="https://github.com/zenml-io/mcp-zenml" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="MIT" \
+      io.modelcontextprotocol.server.name="io.github.zenml-io/mcp-zenml"
 
 ENTRYPOINT ["python", "-u", "server/zenml_server.py"]


### PR DESCRIPTION
This PR adds the required OCI annotation for MCP registry validation.\n\n- Adds io.modelcontextprotocol.server.name=io.github.zenml-io/mcp-zenml label in Dockerfile.\n- Ensures CI injects the same label via docker/metadata-action in both docker-publish and release workflows.\n\nThis enables the MCP registry to verify ownership when pulling from Docker Hub (zenmldocker/mcp-zenml).