### PR TITLE
Add optional analytics via ZenML Analytics Server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `server/` – MCP server implementation. Main entry: `server/zenml_server.py`; analytics: `server/analytics.py`; treat `server/lib/` as vendored support code (avoid edits unless necessary).
+- `server/` – MCP server implementation. Main entry: `server/zenml_server.py`; analytics: `server/zenml_mcp_analytics.py`; treat `server/lib/` as vendored support code (avoid edits unless necessary).
 - `scripts/` – Developer utilities: `format.sh` (ruff) and `test_mcp_server.py` (smoke test).
 - `assets/` – Images and static assets.
 - Root files – `README.md`, `manifest.json`, `mcp-zenml.mcpb` (MCP bundle), CI in `.github/workflows/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ The project is a Model Context Protocol (MCP) server that provides AI assistants
 - Provides comprehensive exception handling with the `@handle_exceptions` decorator
 - Configures minimal logging to prevent JSON protocol interference
 
-**Analytics Module**: `server/analytics.py`
+**Analytics Module**: `server/zenml_mcp_analytics.py`
 - Anonymous usage tracking via the ZenML Analytics Server (opt-out available)
 - Sends events to `https://analytics.zenml.io/batch` with `Source-Context: mcp-zenml`
 - Tracks tool usage, session duration, and error rates

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The ZenML MCP Server collects anonymous usage analytics to help us improve the p
 **We track:**
 - Which tools are used and how often
 - Error rates and types (error type only, no messages)
-- Basic environment info (OS, Python version)
+- Basic environment info (OS, Python version, and whether running in Docker/CI)
 - Session duration and tool usage patterns
 
 **We do NOT collect:**


### PR DESCRIPTION
Adds anonymous usage analytics to help improve the MCP server. Analytics is:
- **Opt-out by default** - users can disable with `ZENML_MCP_ANALYTICS_ENABLED=false`
- **Fire-and-forget** - background daemon thread ensures analytics never blocks tool execution
- **Failure-safe** - analytics errors never affect MCP server functionality
- **Privacy-conscious** - no PII, no server URLs (removed domain hash), error messages sanitized
- **Secure** - No embedded Segment keys (events proxy through ZenML Analytics Server)

## Architecture

Instead of using the Segment SDK directly (which would embed the write key in client code), events are sent via HTTP POST to the ZenML Analytics Server:

```
POST https://analytics.zenml.io/batch
Header: Source-Context: mcp-zenml
Body: [{"type": "track", "user_id": "...", "event": "...", "properties": {...}, "debug": false}]
```

The analytics server handles:
- Segment key management (keys stay server-side)
- Batching and async forwarding
- Rate limiting (500 req/60s per IP/user)
- Retries on transient failures

### Fire-and-forget pattern

Events are enqueued to a bounded queue (max 100 events) and sent by a background daemon thread. This ensures:
- Tool execution is never blocked by analytics (even if the network is slow)
- Queue overflow silently drops events (best-effort delivery)
- Clean shutdown via daemon thread + stop event

## Changes

- **New file**: `server/zenml_mcp_analytics.py` - Analytics module with HTTP transport
- **Modified**: `server/zenml_server.py`:
  - Instrumented tool/prompt decorators with analytics tracking
  - Added explicit `timeout=(3.05, 30)` to all HTTP requests (prevents hangs)
  - Fixed type hints: `str = None` → `str | None = None`
  - Sanitized error messages (type-only in prod, full in dev mode)
- **Modified**: `README.md` - Added Privacy & Analytics section with opt-out documentation
- **Modified**: `CLAUDE.md` and `AGENTS.md` - Documented analytics architecture

## Events Tracked

| Event | When | Key Properties |
|-------|------|----------------|
| MCP Server Started | On startup | version, OS, Python, is_docker, is_ci |
| Tool Called | Every tool invocation | tool_name, duration_ms, success, error_type, size |
| MCP Server Shutdown | On exit | uptime_seconds, total_tool_calls, unique_tools_used |
| Pipeline Triggered | On successful trigger | has_template_id, has_stack_override |
| Client Init Failed | ZenML client init fails | error_type |
| Easter Egg Discovered | When found | - |

## Environment Variables

| Variable | Effect |
|----------|--------|
| `ZENML_MCP_ANALYTICS_ENABLED=false` | Disable analytics entirely |
| `ZENML_MCP_DISABLE_ANALYTICS=true` | Alternative disable (clearer intent) |
| `ZENML_MCP_ANALYTICS_DEV=true` | Dev mode: logs to stderr instead of sending |
| `ZENML_MCP_ANALYTICS_ID` | Override anonymous ID (useful for Docker) |

## Test plan

- [x] Smoke test passes (33/33 tools)
- [x] Events sent to analytics server (200 OK responses)
- [x] Dev mode logs events to stderr correctly
- [x] Opt-out prevents all event tracking
- [x] Shutdown event fires correctly
- [x] Tool schemas preserved (FastMCP correctly follows `__wrapped__`)
- [x] Request timeouts prevent hangs on network issues