### PR TITLE
feat(security): add zizmor GitHub Actions security linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  # Keep GitHub Actions pinned to SHA hashes updated
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # Group all action updates into a single PR to reduce noise
+      all-actions:
+        patterns:
+          - '*'
+    # Prevent Dependabot from flooding the repo with PRs
+    cooldown:
+      default-days: 7

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,23 +19,25 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -49,7 +51,7 @@ jobs:
             io.modelcontextprotocol.server.name=io.github.zenml-io/mcp-zenml
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: ./Dockerfile
@@ -61,4 +63,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
-        run: echo "Digest -> ${{ steps.meta.outputs.digest }}"
+        run: echo "Digest -> ${STEPS_META_OUTPUTS_DIGEST}"
+        env:
+          STEPS_META_OUTPUTS_DIGEST: ${{ steps.meta.outputs.digest }}

--- a/.github/workflows/mcp-smoke-test.yml
+++ b/.github/workflows/mcp-smoke-test.yml
@@ -27,16 +27,18 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           version: "0.7.13"
           enable-cache: true
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       
@@ -49,7 +51,7 @@ jobs:
       
       - name: Create issue on failure
         if: steps.smoke-test.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Check for existing open issues with the same title
@@ -124,7 +126,7 @@ jobs:
       
       - name: Send Discord notification on failure
         if: steps.smoke-test.outcome == 'failure'
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           title: "🚨 MCP Smoke Test Failed"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -31,15 +31,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -57,7 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Build Docker image
         run: |
@@ -92,3 +96,22 @@ jobs:
           else
             echo "⚠️ Warning: Expected analytics status message not found"
           fi
+
+  security-lint:
+    name: Security Lint Workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+
+      - name: Run zizmor security linter
+        run: uvx zizmor --format=github .

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -18,23 +18,25 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -48,7 +50,7 @@ jobs:
             io.modelcontextprotocol.server.name=io.github.zenml-io/mcp-zenml
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           file: ./Dockerfile
@@ -76,20 +78,21 @@ jobs:
         run: ./mcp-publisher publish
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
+          cache: ""
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Build MCP bundle
         run: bash scripts/build_mcpb.sh
 
       - name: Create GitHub Release (auto notes)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,15 @@ on:
         type: boolean
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Run tests first as a gate before releasing
   test-gate:
     name: Pre-release Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       ZENML_DISABLE_RICH_LOGGING: "1"
       ZENML_LOGGING_COLORS_DISABLED: "true"
@@ -37,15 +39,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 
@@ -67,40 +71,50 @@ jobs:
     name: Orchestrate Release
     runs-on: ubuntu-latest
     needs: test-gate  # Only release if tests pass
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository (with PAT)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
+          persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
-          enable-cache: true
+          enable-cache: false
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
+          cache: ""
 
-      - name: Configure Git user
+      - name: Configure Git user and auth
         run: |
           git config user.name "release-bot"
           git config user.email "actions@users.noreply.github.com"
+          # Re-add auth for push since persist-credentials is disabled
+          git remote set-url origin "https://x-access-token:${GH_RELEASE_PAT}@github.com/${{ github.repository }}.git"
+        env:
+          GH_RELEASE_PAT: ${{ secrets.GH_RELEASE_PAT }}
 
       - name: Bump version (SemVer)
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            python scripts/bump_version.py --version "${{ inputs.version }}"
+          if [ -n "${INPUTS_VERSION}" ]; then
+            python scripts/bump_version.py --version "${INPUTS_VERSION}"
           else
             python scripts/bump_version.py
           fi
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
 
       - name: Regenerate manifest fields
         run: python scripts/generate_manifest_fields.py
@@ -115,35 +129,42 @@ jobs:
       - name: Resolve version
         id: resolve_version
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          if [ -n "${INPUTS_VERSION}" ]; then
+            echo "value=${INPUTS_VERSION}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=${{ steps.read_version.outputs.value }}" >> "$GITHUB_OUTPUT"
+            echo "value=${STEPS_READ_VERSION_OUTPUTS_VALUE}" >> "$GITHUB_OUTPUT"
           fi
+        env:
+          INPUTS_VERSION: ${{ inputs.version }}
+          STEPS_READ_VERSION_OUTPUTS_VALUE: ${{ steps.read_version.outputs.value }}
 
       - name: Commit and push changes
         if: ${{ inputs.dry_run != true }}
         run: |
           set -e
           git add VERSION manifest.json server.json mcp-zenml.mcpb
-          git commit -m "chore(release): v${{ steps.resolve_version.outputs.value }}" || echo "No changes to commit"
+          git commit -m "chore(release): v${STEPS_RESOLVE_VERSION_OUTPUTS_VALUE}" || echo "No changes to commit"
           git push origin HEAD:main
+        env:
+          STEPS_RESOLVE_VERSION_OUTPUTS_VALUE: ${{ steps.resolve_version.outputs.value }}
 
       - name: Create and push annotated tag
         if: ${{ inputs.dry_run != true }}
         run: |
           set -e
-          TAG="v${{ steps.resolve_version.outputs.value }}"
+          TAG="v${STEPS_RESOLVE_VERSION_OUTPUTS_VALUE}"
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists locally."
           else
             git tag -a "$TAG" -m "Release $TAG" || true
           fi
           git push origin "$TAG" || true
+        env:
+          STEPS_RESOLVE_VERSION_OUTPUTS_VALUE: ${{ steps.resolve_version.outputs.value }}
 
       - name: Create/Update GitHub Release (attach MCP bundle)
         if: always()
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           tag_name: v${{ steps.resolve_version.outputs.value }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# Zizmor GitHub Actions security linter configuration
+# https://docs.zizmor.sh/configuration/
+#
+# Only add ignores for verified false positives where the source is trusted.
+# Prefer fixing issues over ignoring them.
+
+rules:
+  # Cache-poisoning false positives: setup-node enables caching by default,
+  # but we explicitly disable it with `cache: ""`. Zizmor's static analysis
+  # doesn't evaluate runtime values.
+  cache-poisoning:
+    ignore:
+      - release-docker.yml:81  # setup-node with cache: "" (disabled)
+      - release.yml:95         # setup-node with cache: "" (disabled)


### PR DESCRIPTION
## Summary

Implements comprehensive GitHub Actions security hardening using [zizmor](https://zizmor.sh/), a security linter for GitHub Actions workflows.

### Changes

- **SHA Pinning**: All actions pinned to immutable SHA hashes (prevents supply chain attacks via tag mutation)
- **Credential Persistence**: Added `persist-credentials: false` to all checkout steps
- **Template Injection Fix**: Refactored `release.yml` to pass `${{ inputs.* }}` through environment variables
- **Least Privilege**: Moved `contents: write` from workflow-level to job-level in `release.yml`
- **Cache Poisoning Mitigation**: Disabled default caching on `setup-node` in release workflows
- **CI Enforcement**: Added `security-lint` job to `pr-test.yml` that runs zizmor on every PR
- **Automated Updates**: Added `dependabot.yml` for weekly GitHub Actions updates with cooldown
- **Config**: Added `.github/zizmor.yml` with documented false-positive ignores

### Files Changed

| File | Changes |
|------|---------|
| `.github/dependabot.yml` | **New** - Dependabot config for actions |
| `.github/zizmor.yml` | **New** - Zizmor configuration |
| `.github/workflows/pr-test.yml` | Added security-lint job |
| `.github/workflows/release.yml` | SHA pins, permissions fix, template injection fix |
| `.github/workflows/release-docker.yml` | SHA pins, cache disable |
| `.github/workflows/docker-publish.yml` | SHA pins, persist-credentials |
| `.github/workflows/mcp-smoke-test.yml` | SHA pins, persist-credentials |

## Test plan

- [ ] CI passes (including new security-lint job)
- [ ] Verify locally: `zizmor .` shows "No findings to report"
- [ ] Verify release workflow still works (may need manual test after merge)