### PR TITLE
Detect tool error strings in smoke test

### DIFF
--- a/.github/workflows/mcp-smoke-test.yml
+++ b/.github/workflows/mcp-smoke-test.yml
@@ -47,10 +47,9 @@ jobs:
         run: |
           echo "Running MCP smoke test..."
           uv run scripts/test_mcp_server.py server/zenml_server.py
-        continue-on-error: true
-      
+
       - name: Create issue on failure
-        if: steps.smoke-test.outcome == 'failure'
+        if: always() && steps.smoke-test.outcome == 'failure'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v7
         with:
           script: |
@@ -125,7 +124,7 @@ jobs:
             }
       
       - name: Send Discord notification on failure
-        if: steps.smoke-test.outcome == 'failure'
+        if: always() && steps.smoke-test.outcome == 'failure'
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
## Summary

The smoke test was marking tools as "successful" even when they returned error messages (like `"Authentication failed"`) because:

1. The server's `@handle_tool_exceptions` decorator converts exceptions to string responses rather than raising MCP protocol errors
2. The test only checked if `result.content` exists, not whether the content indicates an error
3. Error messages are valid MCP content, so tests passed even when tools functionally failed

This PR fixes that by adding error string detection to the smoke test.

## Changes

### `scripts/test_mcp_server.py`
- **Add helper functions:**
  - `_extract_call_tool_text()` - Flattens MCP responses into text for inspection
  - `_detect_tool_error()` - Pattern-matches against known error prefixes from `handle_tool_exceptions`
- **Update tool test logic** to check content for error strings and mark as failed accordingly
- **Include tool test failures** in overall pass/fail status and exit code
- **Fix `safe_tools_to_test` list:**
  - Remove `get_server_info` (doesn't exist)
  - Add `get_active_user` and `list_artifacts` (safe, no required params)
  - Add comment about not adding tools with required parameters

### `.github/workflows/mcp-smoke-test.yml`
- Remove `continue-on-error: true` so the job properly fails when tests fail
- Add `always() &&` to notification steps so they still run when the job fails

## Test Plan

- [x] Ran smoke test locally - all 11 tools pass
- [x] Verified exit code is 0 on success
- [x] Ran `./scripts/format.sh` - linting and type checks pass
- [ ] CI will verify the changes work in the CI environment