### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ It provides a unified interface for managing data, models, and experiments.
 
 For more information, see the [ZenML website](https://zenml.io) and [our documentation](https://docs.zenml.io).
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/zenml-io-mcp-zenml).
+
 ## Features
 
 The server provides MCP tools to access core read functionality from the ZenML


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/zenml-io-mcp-zenml)