### PR TITLE
Harden release workflow repository interpolation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,10 @@ jobs:
           git config user.name "release-bot"
           git config user.email "actions@users.noreply.github.com"
           # Re-add auth for push since persist-credentials is disabled
-          git remote set-url origin "https://x-access-token:${GH_RELEASE_PAT}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${GH_RELEASE_PAT}@github.com/${GITHUB_REPO}.git"
         env:
           GH_RELEASE_PAT: ${{ secrets.GH_RELEASE_PAT }}
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Bump version (SemVer)
         run: |


### PR DESCRIPTION
## Summary
- pass github.repository through GITHUB_REPO env before using it in the release shell command
- verified release-docker.yml already pins the MCP Registry checkout to c5c4b9e8890dd5754bee889b2f1417f4fe3b5ce5

## Validation
- uvx zizmor==1.25.2 --format=github --config=.github/zizmor.yml .github/workflows/

Closes #52