### PR TITLE
Fix ty type checking by moving rules into PEP 723 headers and pinning `ty@0.0.79`

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -144,4 +144,4 @@ jobs:
       - name: Run ty type checker
         run: |
           echo "Running ty type checker..."
-          uvx ty check --output-format=github
+          uvx ty@0.0.79 check --output-format=github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Run unit tests**: `uv run scripts/test_datetime_normalization.py`
 - **Format code**: `./scripts/format.sh` (uses ruff for linting/formatting + ty for type checking)
 - **Run MCP server locally**: `uv run server/zenml_server.py`
-- **Type check only**: `uvx ty check` (runs type checking without formatting)
+- **Type check only**: `uvx ty@0.0.79 check` (runs type checking without formatting)
 - **Check PEP 723 dependency drift**: `python scripts/check_pep723_requirements.py`
 - **Validate hashed requirements**: `uv pip install --dry-run --require-hashes -r requirements.txt` inside an active virtualenv (CI creates a throwaway Python 3.12 environment under the runner temp directory for this check)
 - **Run workflow security scan**: `GH_TOKEN=$(gh auth token) uvx zizmor==1.25.2 --format=github --config=.github/zizmor.yml .github/workflows/`
 
 ### Code Quality
 - **Format + Type Check**: `bash scripts/format.sh` (runs ruff + ty)
-- **Type Check Only**: `uvx ty check` (uses configuration from `pyproject.toml`)
+- **Type Check Only**: `uvx ty@0.0.79 check` (rule config lives in each file's PEP 723 header, see below)
 - **Recompile requirements**: `uv pip compile --generate-hashes --exclude-newer "7 days" --python-version 3.12 requirements.in -o requirements.txt`
 - **Check PEP 723 dependency drift**: use the canonical command listed under Testing and Development above.
 - **Validate hashed requirements**: `uv pip install --dry-run --require-hashes -r requirements.txt` inside an active virtualenv
@@ -259,7 +259,7 @@ This prints a public URL like `https://random-words.trycloudflare.com`.
 
 The project uses [ty](https://docs.astral.sh/ty/) for static type checking - an extremely fast Python type checker from Astral (creators of uv and ruff).
 
-**Configuration**: `pyproject.toml` under `[tool.ty]`
+**Configuration**: `pyproject.toml` under `[tool.ty]` (applies to files without a PEP 723 header; scripts carry their own `[tool.ty]` blocks in their header, see the note below)
 - Python version: 3.12
 - Extra paths: `server/` (allows `import zenml_mcp_analytics` to resolve)
 - Include patterns: `server/**/*.py`, `scripts/**/*.py`
@@ -267,8 +267,8 @@ The project uses [ty](https://docs.astral.sh/ty/) for static type checking - an 
 
 **Running type checks**:
 ```bash
-uvx ty check                    # Basic check
-uvx ty check --output-format=github  # For CI (annotations)
+uvx ty@0.0.79 check             # Basic check (same pin as CI)
+uvx ty@0.0.79 check --output-format=github  # For CI (annotations)
 bash scripts/format.sh          # Runs ruff + ty together
 ```
 
@@ -276,7 +276,7 @@ bash scripts/format.sh          # Runs ruff + ty together
 
 **CI Integration**: Type checking runs as a separate job in PR tests (`.github/workflows/pr-test.yml`).
 
-**Note on third-party imports**: Since this project uses PEP 723 inline script metadata for dependencies (installed on-the-fly by `uv run`), ty runs in isolation and can't see them. The `unresolved-import = "ignore"` setting handles this. First-party imports (like `zenml_mcp_analytics`) are still checked.
+**Note on third-party imports**: Since this project uses PEP 723 inline script metadata for dependencies (installed on-the-fly by `uv run`), ty runs in isolation and can't see them. Since ty 0.0.62, any file with a PEP 723 header is treated as its own project and takes its rules from that header, not from `pyproject.toml`. So every PEP 723 script carries a `[tool.ty.rules]` block with `unresolved-import = "ignore"`, and scripts that import from `server/` also carry `[tool.ty.environment]` with `extra-paths = ["../server"]` so first-party imports (like `zenml_mcp_analytics`) are still checked. When adding a new PEP 723 script, copy those blocks into its header. ty is pinned in CI and `scripts/format.sh`; bump both together.
 
 ### Important Implementation Details
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ exclude = [
 # Default: most rules are "error", some are "warn", some are "ignore"
 # See: https://docs.astral.sh/ty/reference/rules/
 
-# Ignore unresolved imports for third-party libraries.
-# This project uses PEP 723 inline script metadata for dependencies,
-# which are installed on-the-fly by `uv run`. ty runs in isolation
-# and doesn't see these deps, so we ignore import errors for them.
+# Ignore unresolved imports for third-party libraries (installed on the fly
+# by `uv run`, so ty cannot see them). NOTE: since ty 0.0.62 this section only
+# applies to files WITHOUT a PEP 723 header (e.g. server/zenml_mcp_analytics.py).
+# Each PEP 723 script carries its own [tool.ty.rules] block in its header.
 unresolved-import = "ignore"
 
 [tool.ty.terminal]

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -18,7 +18,7 @@ ruff check $SRC --select F401,F841 --fix --exclude "__init__.py" --isolated
 ruff check $SRC --select I --fix --ignore D
 ruff format $SRC
 
-# Type checking with ty (uses pyproject.toml configuration)
+# Type checking with ty (pinned; PEP 723 scripts carry their own [tool.ty] config in their header)
 echo ""
 echo "Running type checks with ty..."
-uvx ty check
+uvx ty@0.0.79 check

--- a/scripts/test_analytics.py
+++ b/scripts/test_analytics.py
@@ -4,6 +4,13 @@
 # dependencies = [
 #     "httpx",
 # ]
+#
+# [tool.ty.rules]
+# # ty >=0.0.62 takes rules from this block, not pyproject.toml. See CLAUDE.md "Note on third-party imports".
+# unresolved-import = "ignore"
+#
+# [tool.ty.environment]
+# extra-paths = ["../server"]
 # ///
 """
 Diagnostic script to test ZenML MCP analytics pipeline.

--- a/scripts/test_datetime_normalization.py
+++ b/scripts/test_datetime_normalization.py
@@ -8,6 +8,13 @@
 #     "setuptools",
 #     "requests>=2.32.0",
 # ]
+#
+# [tool.ty.rules]
+# # ty >=0.0.62 takes rules from this block, not pyproject.toml. See CLAUDE.md "Note on third-party imports".
+# unresolved-import = "ignore"
+#
+# [tool.ty.environment]
+# extra-paths = ["../server"]
 # ///
 """
 Unit tests for datetime filter normalization and exception classification.

--- a/scripts/test_mcp_server.py
+++ b/scripts/test_mcp_server.py
@@ -7,6 +7,10 @@
 #     "setuptools",
 #     "requests>=2.32.0",
 # ]
+#
+# [tool.ty.rules]
+# # ty >=0.0.62 takes rules from this block, not pyproject.toml. See CLAUDE.md "Note on third-party imports".
+# unresolved-import = "ignore"
 # ///
 import asyncio
 import json

--- a/server/zenml_server.py
+++ b/server/zenml_server.py
@@ -7,6 +7,10 @@
 #     "setuptools",
 #     "requests>=2.32.0",
 # ]
+#
+# [tool.ty.rules]
+# # ty >=0.0.62 takes rules from this block, not pyproject.toml. See CLAUDE.md "Note on third-party imports".
+# unresolved-import = "ignore"
 # ///
 
 # Ensure setuptools is imported first to provide distutils compatibility


### PR DESCRIPTION
## Why

The `Type Checking` job has been red on every PR since ty 0.0.62 (released 2026-07-22, a week after the last green run on `main`). CI runs `uvx ty check` unpinned, so it picked up the new release silently. It first surfaced on the Dependabot PR #69, which only touches workflow files and cannot have caused it.

ty 0.0.62 [started respecting `rules` inside PEP 723 script metadata](https://github.com/astral-sh/ruff/pull/26671): any file with a `# /// script` header is now treated as its own project and takes its config from that header, not from `pyproject.toml`. Every checked file in this repo has such a header, so the `unresolved-import = "ignore"` rule and the `extra-paths = ["server"]` setting stopped applying and 14 import errors appeared. The ty maintainer has [confirmed this is intentional](https://github.com/astral-sh/ty/issues/4083).

## What

- Add a `[tool.ty.rules]` block with `unresolved-import = "ignore"` to the PEP 723 header of all four scripts.
- Add `[tool.ty.environment] extra-paths = ["../server"]` to the two scripts that import from `server/`, so first-party imports like `zenml_mcp_analytics` are still type-checked.
- Pin `uvx ty@0.0.79` in `pr-test.yml` and `scripts/format.sh`.
- Reword the `pyproject.toml` `[tool.ty]` comment (it still applies to `server/zenml_mcp_analytics.py`, which has no header) and update CLAUDE.md.

Verified locally: `uvx ty@0.0.79 check` goes from 14 diagnostics to "All checks passed!", `scripts/check_pep723_requirements.py` and the datetime unit tests still pass. A `ty.toml` at repo root was tested and does not reach PEP 723 scripts, so the per-header block is the sanctioned place for this config.

Unblocks #69.