### PR TITLE
Pin `ty` once in `requirements-dev.txt` and let Dependabot bump it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,14 @@ updates:
     # Prevent Dependabot from flooding the repo with PRs
     cooldown:
       default-days: 7
+
+  # Keep dev tool pins in requirements-dev.txt (currently just ty) updated.
+  # Restricted to ty so Dependabot never rewrites the hashed requirements.txt.
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-name: ty
+    cooldown:
+      default-days: 7

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -144,4 +144,4 @@ jobs:
       - name: Run ty type checker
         run: |
           echo "Running ty type checker..."
-          uvx ty@0.0.79 check --output-format=github
+          uvx --constraints requirements-dev.txt ty check --output-format=github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Run unit tests**: `uv run scripts/test_datetime_normalization.py`
 - **Format code**: `./scripts/format.sh` (uses ruff for linting/formatting + ty for type checking)
 - **Run MCP server locally**: `uv run server/zenml_server.py`
-- **Type check only**: `uvx ty@0.0.79 check` (runs type checking without formatting)
+- **Type check only**: `uvx --constraints requirements-dev.txt ty check` (runs type checking without formatting)
 - **Check PEP 723 dependency drift**: `python scripts/check_pep723_requirements.py`
 - **Validate hashed requirements**: `uv pip install --dry-run --require-hashes -r requirements.txt` inside an active virtualenv (CI creates a throwaway Python 3.12 environment under the runner temp directory for this check)
 - **Run workflow security scan**: `GH_TOKEN=$(gh auth token) uvx zizmor==1.25.2 --format=github --config=.github/zizmor.yml .github/workflows/`
 
 ### Code Quality
 - **Format + Type Check**: `bash scripts/format.sh` (runs ruff + ty)
-- **Type Check Only**: `uvx ty@0.0.79 check` (rule config lives in each file's PEP 723 header, see below)
+- **Type Check Only**: `uvx --constraints requirements-dev.txt ty check` (rule config lives in each file's PEP 723 header, see below)
 - **Recompile requirements**: `uv pip compile --generate-hashes --exclude-newer "7 days" --python-version 3.12 requirements.in -o requirements.txt`
 - **Check PEP 723 dependency drift**: use the canonical command listed under Testing and Development above.
 - **Validate hashed requirements**: `uv pip install --dry-run --require-hashes -r requirements.txt` inside an active virtualenv
@@ -267,8 +267,8 @@ The project uses [ty](https://docs.astral.sh/ty/) for static type checking - an 
 
 **Running type checks**:
 ```bash
-uvx ty@0.0.79 check             # Basic check (same pin as CI)
-uvx ty@0.0.79 check --output-format=github  # For CI (annotations)
+uvx --constraints requirements-dev.txt ty check             # Basic check (same pin as CI)
+uvx --constraints requirements-dev.txt ty check --output-format=github  # For CI (annotations)
 bash scripts/format.sh          # Runs ruff + ty together
 ```
 
@@ -276,7 +276,7 @@ bash scripts/format.sh          # Runs ruff + ty together
 
 **CI Integration**: Type checking runs as a separate job in PR tests (`.github/workflows/pr-test.yml`).
 
-**Note on third-party imports**: Since this project uses PEP 723 inline script metadata for dependencies (installed on-the-fly by `uv run`), ty runs in isolation and can't see them. Since ty 0.0.62, any file with a PEP 723 header is treated as its own project and takes its rules from that header, not from `pyproject.toml`. So every PEP 723 script carries a `[tool.ty.rules]` block with `unresolved-import = "ignore"`, and scripts that import from `server/` also carry `[tool.ty.environment]` with `extra-paths = ["../server"]` so first-party imports (like `zenml_mcp_analytics`) are still checked. When adding a new PEP 723 script, copy those blocks into its header. ty is pinned in CI and `scripts/format.sh`; bump both together.
+**Note on third-party imports**: Since this project uses PEP 723 inline script metadata for dependencies (installed on-the-fly by `uv run`), ty runs in isolation and can't see them. Since ty 0.0.62, any file with a PEP 723 header is treated as its own project and takes its rules from that header, not from `pyproject.toml`. So every PEP 723 script carries a `[tool.ty.rules]` block with `unresolved-import = "ignore"`, and scripts that import from `server/` also carry `[tool.ty.environment]` with `extra-paths = ["../server"]` so first-party imports (like `zenml_mcp_analytics`) are still checked. When adding a new PEP 723 script, copy those blocks into its header. ty is pinned once in `requirements-dev.txt`, which CI and `scripts/format.sh` pass to `uvx --constraints`; Dependabot opens a PR when a new ty release is available.
 
 ### Important Implementation Details
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Dev tool pins used as uvx constraints (see scripts/format.sh and pr-test.yml).
+# Dependabot bumps these (pip ecosystem in .github/dependabot.yml).
+ty==0.0.79

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -21,4 +21,4 @@ ruff format $SRC
 # Type checking with ty (pinned; PEP 723 scripts carry their own [tool.ty] config in their header)
 echo ""
 echo "Running type checks with ty..."
-uvx ty@0.0.79 check
+uvx --constraints requirements-dev.txt ty check


### PR DESCRIPTION
Follow-up to #70, stacked on that branch (GitHub will retarget this to `main` once #70 merges).

## Why

#70 pinned `ty@0.0.79` inline in CI, `scripts/format.sh`, and CLAUDE.md. That stops silent breakage, but nothing would ever move the pin, so it would rot. This gives the pin a single home and an automatic nudge, the same discipline the repo already uses for GitHub Actions.

## What

- `requirements-dev.txt`: one line, `ty==0.0.79`. Kept out of `pyproject.toml` on purpose, since that file says not to add dependencies there.
- CI and `format.sh` now run `uvx --constraints requirements-dev.txt ty check`, so the version comes from the file.
- `dependabot.yml`: new `pip` ecosystem entry restricted with `allow: dependency-name: ty`, weekly, 7-day cooldown. The restriction means Dependabot will not try to rewrite the hashed `requirements.txt`.
- CLAUDE.md updated to match.

Verified locally: `uvx --constraints requirements-dev.txt ty --version` reports 0.0.79 and `ty check` passes.